### PR TITLE
Add zoom-on-hover effect to card images

### DIFF
--- a/resources/js/components/CardImage.vue
+++ b/resources/js/components/CardImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card w-100 bg-dark rounded-0 border-0 shadow-sm d-inline-block">
+  <div class="card w-100 bg-dark rounded-0 border-0 shadow-sm d-inline-block card-img-zoom">
     <img :src="src" class="card-img rounded-0" alt="" v-if="src">
     <div class="card-img-overlay d-flex align-items-end" v-if="title">
       <p class="text-muted mx-auto">{{ title }}</p>

--- a/resources/scss/app.scss
+++ b/resources/scss/app.scss
@@ -35,3 +35,13 @@ body {
 	outline: none;
 	box-shadow: none;
 }
+
+.card-img-zoom {
+	overflow: hidden;
+}
+.card-img-zoom img {
+	transition: transform ease .5s;
+}
+.card-img-zoom:hover img {
+	transform: scale(1.2);
+}


### PR DESCRIPTION
Fixes #26 

### Summary
* Add zoom on hover effect to photo cards (on desktop)