### PR TITLE
Add options-dropdown to photos for social media share links 

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           <card-image image="public/img/cards/200-150.jpg"></card-image>
         </section>
 
-        <div class="d-flex justify-content-center overflow-auto" data-aos="fade-up" data-aos-delay="550">
+        <div class="d-flex justify-content-center overflow-auto" data-aos="zoom-in-right" data-aos-delay="550">
           <a href="photos.html" class="link lead">
             View More Photos
             <i class="material-icons md-18 ml-1">arrow_forward</i>

--- a/photos.html
+++ b/photos.html
@@ -47,6 +47,12 @@
         <section id="photos" class="card-columns mt-4" data-aos="fade-up" data-aos-delay="550">
           <card-image image="public/img/nature/1.jpg" title="Sample Title"
             tags="nature">
+            <template v-slot:options>
+              <options-dropdown>
+                <a href="#" class="dropdown-item" target="_blank">Link</a>
+                <a href="#" class="dropdown-item" target="_blank">Link</a>
+              </options-dropdown>
+            </template>
           </card-image>
 
           <card-image image="public/img/people/1.jpeg"
@@ -78,7 +84,7 @@
           </card-image>
         </section>
 
-        <div class="d-flex justify-content-center overflow-auto" data-aos="fade-up" data-aos-delay="550">
+        <div class="d-flex justify-content-center overflow-auto" data-aos="zoom-in-left" data-aos-delay="550">
           <a href="index.html" class="link lead">
             <i class="material-icons md-18 mr-1">arrow_back</i>
             Home

--- a/resources/js/components/CardImage.vue
+++ b/resources/js/components/CardImage.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="card w-100 bg-dark rounded-0 border-0 shadow-sm d-inline-block card-img-zoom"
     :class="tags">
+    <div class="card-header border-0 position-absolute w-100 top-0 z-10">
+      <h5 class="my-auto">
+        <slot name="options"></slot>
+      </h5>
+    </div>
     <img :src="image" class="card-img rounded-0" alt="" v-if="image">
     <div class="card-img-overlay d-flex align-items-end" v-if="title">
       <p class="text-muted mx-auto">{{ title }}</p>

--- a/resources/scss/_custom.scss
+++ b/resources/scss/_custom.scss
@@ -51,3 +51,11 @@ body {
 .card-img-zoom:hover img {
 	transform: scale(1.2);
 }
+
+.z-10 {
+	z-index: 10;
+}
+
+.top-0 {
+	top: 0;
+}


### PR DESCRIPTION
Fixes #27 

### Summary
* Add slot for options on card image component
* Add sample `<options-dropdown>` component to options slot on one card image